### PR TITLE
Logger batching interval

### DIFF
--- a/packages/logger/src/utils/batcher/index.ts
+++ b/packages/logger/src/utils/batcher/index.ts
@@ -1,18 +1,20 @@
 export class Batcher<T> {
+	private timeout?: ReturnType<typeof setTimeout>
 	private queue: T[] = []
 
-	constructor(interval: number, private readonly handler: (queue: T[]) => void) {
-		setInterval(() => this.dropIfNeeded(), interval)
+	constructor(private readonly interval: number, private readonly handler: (queue: T[]) => void) {
 	}
 
 	add(item: T) {
 		this.queue.push(item)
+		if (!this.timeout) {
+			this.timeout = setTimeout(() => this.drop(), this.interval)
+		}
 	}
 
-	dropIfNeeded() {
-		if (this.queue.length > 0) {
-			this.handler(this.queue)
-			this.queue = []
-		}
+	drop() {
+		this.handler(this.queue)
+		this.queue = []
+		this.timeout = undefined
 	}
 }


### PR DESCRIPTION
In order to correctly finishing node process, setInterval replaced with setTimeout on demand